### PR TITLE
add "pymdown-extensions" to support nonascii anchor

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,8 @@ markdown_extensions:
   - pymdownx.tabbed
   - pymdownx.tilde
   - admonition
+  - toc:
+      slugify: !!python/name:pymdownx.slugs.uslugify
 
 extra_css:
   - stylesheets/extra.css

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs
 mkdocs-material
+pymdown-extensions


### PR DESCRIPTION
不知道 cf bot 能不能支持装 requirements.txt

以及可能需要检查之前的文章防止破坏 -- 之前的文章如果使用了数字锚点 (比如 `#_2`) 或者默认的英文锚点, 则其链接可能会 broken